### PR TITLE
バッファリング停滞（グルグル）時の自動復旧機能を追加

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,6 +34,7 @@
 
    <script src="js/main.js"></script>
    <script src="js/history.js"></script>
+   <script src="js/stall-recovery.js"></script>
 </body>
 
 </html>

--- a/js/stall-recovery.js
+++ b/js/stall-recovery.js
@@ -1,0 +1,234 @@
+// バッファリング停滞（グルグル）の自動復旧
+// 再生位置が一定時間進まない場合に「先にスキップ → 動画再ロード → ページ再読み込み」と段階的に復旧する
+(function () {
+  // ===== 定数 =====
+  var TICK_MS = 1000;                  // 監視間隔
+  var STALL_TIMEOUT_MS = 20000;        // この時間進捗がなければ停滞と判定（広告誤検知対策で20秒）
+  var HEALTHY_RESET_MS = 30000;        // この時間正常再生が続いたらレベルをリセット
+  var PROGRESS_EPSILON = 0.05;         // 再生位置の変化とみなす最小秒数
+  var SKIP_AHEAD_SEC = 10;             // レベル0で先にスキップする秒数
+  var RELOAD_GUARD_MAX = 2;            // リロードループ防止: 窓内の上限回数
+  var RELOAD_GUARD_WINDOW_MS = 600000; // リロード回数のカウント窓（10分）
+  var RESTORE_EXPIRE_MS = 120000;      // リロード後の位置復元の有効期限（2分）
+  var RESTORE_KEY = 'ytStallRestore';
+  var RELOAD_COUNT_KEY = 'ytStallReloadCount';
+
+  // ===== 状態 =====
+  var lastTime = null;             // 前回tickの再生位置
+  var lastFraction = 0;            // 前回tickのバッファ読み込み割合
+  var lastProgressAt = Date.now(); // 最後に進捗を確認した時刻
+  var lastActionAt = 0;            // 最後に復旧アクションを実行した時刻
+  var recoveryLevel = 0;           // 0:先にシーク / 1:動画再ロード / 2:ページ再読み込み
+  var healthySince = null;         // 正常再生が続いている開始時刻
+  var pendingRestore = loadPendingRestore(); // リロード後の復元情報
+
+  // リロード前に保存した復元情報を読み出す（読み出したら即削除）
+  function loadPendingRestore() {
+    try {
+      var raw = sessionStorage.getItem(RESTORE_KEY);
+      sessionStorage.removeItem(RESTORE_KEY);
+      if (!raw) return null;
+      var data = JSON.parse(raw);
+      if (!data || Date.now() - data.ts > RESTORE_EXPIRE_MS) return null;
+      return data;
+    } catch (e) {
+      return null;
+    }
+  }
+
+  function getCurrentVideoId() {
+    var data = typeof player.getVideoData === 'function' ? player.getVideoData() : null;
+    if (data && data.video_id) return data.video_id;
+    // フォールバック: 入力欄のURLから抽出
+    var url = document.getElementById('youtubeUrl').value;
+    return typeof extractVideoId === 'function' ? extractVideoId(url) : null;
+  }
+
+  // PLAYING（位置が凍結）と BUFFERING のみ停滞候補。PAUSED/CUED/UNSTARTED/ENDED は対象外
+  function isStallCandidateState(state) {
+    return state === YT.PlayerState.PLAYING || state === YT.PlayerState.BUFFERING;
+  }
+
+  function reloadGuardExceeded(now) {
+    try {
+      var raw = sessionStorage.getItem(RELOAD_COUNT_KEY);
+      if (!raw) return false;
+      var data = JSON.parse(raw);
+      if (!data || now - data.since > RELOAD_GUARD_WINDOW_MS) return false;
+      return data.count >= RELOAD_GUARD_MAX;
+    } catch (e) {
+      return false;
+    }
+  }
+
+  function bumpReloadCount(now) {
+    var data = { count: 1, since: now };
+    try {
+      var prev = JSON.parse(sessionStorage.getItem(RELOAD_COUNT_KEY));
+      if (prev && now - prev.since <= RELOAD_GUARD_WINDOW_MS) {
+        data = { count: prev.count + 1, since: prev.since };
+      }
+    } catch (e) { /* 破損時は初期値のまま */ }
+    try { sessionStorage.setItem(RELOAD_COUNT_KEY, JSON.stringify(data)); } catch (e) { }
+  }
+
+  function clearReloadCount() {
+    try { sessionStorage.removeItem(RELOAD_COUNT_KEY); } catch (e) { }
+  }
+
+  function buildReloadUrl() {
+    var params = new URLSearchParams(window.location.search);
+    var url = document.getElementById('youtubeUrl').value;
+    // main.jsがdecodeURIComponentで二重デコードするため、二重エンコードしておく
+    params.set('url', encodeURIComponent(url));
+    return window.location.pathname + '?' + params.toString();
+  }
+
+  function reportStall(level) {
+    if (typeof gtag === 'function') {
+      gtag('event', 'stall_recovery', { level: level });
+    }
+  }
+
+  // ページ再読み込み後、再生が始まったら保存しておいた位置へ1回だけ復元する
+  function applyPendingRestore() {
+    if (!pendingRestore) return;
+    if (Date.now() - pendingRestore.ts > RESTORE_EXPIRE_MS) {
+      pendingRestore = null;
+      return;
+    }
+    if (player.getPlayerState() !== YT.PlayerState.PLAYING) return;
+    if (pendingRestore.isPlaylist) {
+      var index = player.getPlaylistIndex();
+      if (typeof pendingRestore.playlistIndex === 'number' && index !== pendingRestore.playlistIndex) {
+        if (pendingRestore.jumped) {
+          // インデックス移動に失敗 → 諦める
+          pendingRestore = null;
+          return;
+        }
+        pendingRestore.jumped = true;
+        player.playVideoAt(pendingRestore.playlistIndex);
+        return; // 次のtick以降で位置を復元する
+      }
+    } else {
+      var data = typeof player.getVideoData === 'function' ? player.getVideoData() : null;
+      if (!data || data.video_id !== pendingRestore.videoId) return;
+    }
+    if (typeof pendingRestore.time === 'number' && pendingRestore.time > 0) {
+      player.seekTo(pendingRestore.time, true);
+    }
+    pendingRestore = null;
+  }
+
+  function doRecovery(now, currentTime) {
+    lastActionAt = now;
+    var level = recoveryLevel;
+    if (level >= 2 && reloadGuardExceeded(now)) {
+      level = 1; // リロード回数上限に達したらレベル1の再試行に留める
+    }
+    reportStall(level);
+    if (level === 0) {
+      // レベル0: 少し先にスキップして読み込みを蹴り直す
+      console.log('[stall-recovery] レベル0: ' + SKIP_AHEAD_SEC + '秒先へスキップ');
+      player.seekTo(currentTime + SKIP_AHEAD_SEC, true);
+      player.playVideo();
+      recoveryLevel = 1;
+    } else if (level === 1) {
+      if (isPlaylist) {
+        // プレイリストは次の動画へ進む
+        console.log('[stall-recovery] レベル1: 次の動画へ');
+        player.nextVideo();
+      } else {
+        // 単一動画は同じ位置から再ロード
+        console.log('[stall-recovery] レベル1: 動画を再ロード');
+        player.loadVideoById({ videoId: getCurrentVideoId(), startSeconds: currentTime });
+        player.unMute();
+      }
+      recoveryLevel = 2;
+    } else {
+      // レベル2: ページごと再読み込み（既存の ?url= 自動再生パスに乗せる）
+      console.log('[stall-recovery] レベル2: ページを再読み込み');
+      bumpReloadCount(now);
+      try {
+        sessionStorage.setItem(RESTORE_KEY, JSON.stringify({
+          videoId: getCurrentVideoId(),
+          time: currentTime,
+          playlistIndex: isPlaylist ? player.getPlaylistIndex() : null,
+          isPlaylist: !!isPlaylist,
+          ts: now
+        }));
+      } catch (e) { }
+      window.location.replace(buildReloadUrl());
+    }
+  }
+
+  function tick() {
+    if (!window.player || typeof player.getPlayerState !== 'function') return;
+    var now = Date.now();
+    applyPendingRestore();
+
+    var state = player.getPlayerState();
+    var t = player.getCurrentTime();
+    var frac = typeof player.getVideoLoadedFraction === 'function' ? player.getVideoLoadedFraction() : 0;
+    var hasTime = typeof t === 'number' && isFinite(t);
+
+    // 進捗チェック: 再生位置の変化（ループのシーク戻りも進捗とみなすため前後どちらでも）
+    // またはバッファ読み込み割合の増加（広告中・低速回線での誤検知防止）
+    var progressed = false;
+    if (hasTime) {
+      if (lastTime === null || Math.abs(t - lastTime) >= PROGRESS_EPSILON) progressed = true;
+      lastTime = t;
+    }
+    if (typeof frac === 'number') {
+      if (frac - lastFraction > 0.001) progressed = true;
+      lastFraction = frac;
+    }
+    if (progressed) {
+      lastProgressAt = now;
+    }
+
+    // PLAYING/BUFFERING以外は停滞扱いしない
+    if (!isStallCandidateState(state)) {
+      lastProgressAt = now;
+      healthySince = null;
+      return;
+    }
+
+    // 何もロードされていない（停止中など）なら対象外
+    if (!getCurrentVideoId()) {
+      lastProgressAt = now;
+      return;
+    }
+
+    // 正常再生が一定時間続いたらレベルとリロード回数をリセット
+    if (state === YT.PlayerState.PLAYING && progressed) {
+      if (healthySince === null) healthySince = now;
+      if (now - healthySince >= HEALTHY_RESET_MS) {
+        recoveryLevel = 0;
+        clearReloadCount();
+      }
+    } else if (!progressed) {
+      healthySince = null;
+    }
+
+    // 停滞判定 → 段階的復旧（オフライン中は回線復帰を待つ）
+    if (now - lastProgressAt >= STALL_TIMEOUT_MS && now - lastActionAt >= STALL_TIMEOUT_MS) {
+      if (navigator.onLine === false) return;
+      doRecovery(now, hasTime ? t : 0);
+    }
+  }
+
+  // バックグラウンドタブ復帰直後・回線復帰直後の誤発火を防ぐ（1停滞期間の猶予を与える）
+  document.addEventListener('visibilitychange', function () {
+    if (!document.hidden) {
+      lastProgressAt = Date.now();
+      lastActionAt = Date.now();
+    }
+  });
+  window.addEventListener('online', function () {
+    lastProgressAt = Date.now();
+    lastActionAt = Date.now();
+  });
+
+  setInterval(tick, TICK_MS);
+})();

--- a/js/stall-recovery.js
+++ b/js/stall-recovery.js
@@ -3,7 +3,8 @@
 (function () {
   // ===== 定数 =====
   var TICK_MS = 1000;                  // 監視間隔
-  var STALL_TIMEOUT_MS = 20000;        // この時間進捗がなければ停滞と判定（広告誤検知対策で20秒）
+  var STALL_TIMEOUT_MS = 3000;         // この時間進捗がなければ停滞と判定
+  var NETWORK_PROBE_TIMEOUT_MS = 2500; // ネットワーク疎通確認のタイムアウト
   var HEALTHY_RESET_MS = 30000;        // この時間正常再生が続いたらレベルをリセット
   var PROGRESS_EPSILON = 0.05;         // 再生位置の変化とみなす最小秒数
   var SKIP_AHEAD_SEC = 10;             // レベル0で先にスキップする秒数
@@ -20,6 +21,7 @@
   var lastActionAt = 0;            // 最後に復旧アクションを実行した時刻
   var recoveryLevel = 0;           // 0:先にシーク / 1:動画再ロード / 2:ページ再読み込み
   var healthySince = null;         // 正常再生が続いている開始時刻
+  var probing = false;             // ネットワーク疎通確認中フラグ
   var pendingRestore = loadPendingRestore(); // リロード後の復元情報
 
   // リロード前に保存した復元情報を読み出す（読み出したら即削除）
@@ -82,6 +84,16 @@
     // main.jsがdecodeURIComponentで二重デコードするため、二重エンコードしておく
     params.set('url', encodeURIComponent(url));
     return window.location.pathname + '?' + params.toString();
+  }
+
+  // 停滞の原因がネットワークかどうかをYouTubeへの疎通で確認する
+  // 疎通あり = プレイヤー側の問題 → 復旧アクション / 疎通なし = ネットワークが原因 → 待機
+  function probeNetwork(callback) {
+    var controller = new AbortController();
+    var timer = setTimeout(function () { controller.abort(); }, NETWORK_PROBE_TIMEOUT_MS);
+    fetch('https://www.youtube.com/favicon.ico', { mode: 'no-cors', cache: 'no-store', signal: controller.signal })
+      .then(function () { clearTimeout(timer); callback(true); })
+      .catch(function () { clearTimeout(timer); callback(false); });
   }
 
   function reportStall(level) {
@@ -211,10 +223,23 @@
       healthySince = null;
     }
 
-    // 停滞判定 → 段階的復旧（オフライン中は回線復帰を待つ）
-    if (now - lastProgressAt >= STALL_TIMEOUT_MS && now - lastActionAt >= STALL_TIMEOUT_MS) {
-      if (navigator.onLine === false) return;
-      doRecovery(now, hasTime ? t : 0);
+    // 停滞判定 → ネットワークが原因なら待機、プレイヤー側の問題なら段階的復旧
+    if (now - lastProgressAt >= STALL_TIMEOUT_MS && now - lastActionAt >= STALL_TIMEOUT_MS && !probing) {
+      if (navigator.onLine === false) return; // 明らかにオフライン → 回線復帰を待つ
+      probing = true;
+      var stalledTime = hasTime ? t : 0;
+      probeNetwork(function (ok) {
+        probing = false;
+        if (!ok) {
+          // ネットワークが原因 → 復旧アクションはせず、そのまま回線回復を待つ
+          console.log('[stall-recovery] ネットワーク疎通なし: 回線回復を待機');
+          lastActionAt = Date.now(); // 次の疎通確認まで間隔を空ける
+          return;
+        }
+        // 疎通確認中に再生が進んでいたら何もしない
+        if (Date.now() - lastProgressAt < STALL_TIMEOUT_MS) return;
+        doRecovery(Date.now(), stalledTime);
+      });
     }
   }
 


### PR DESCRIPTION
## 概要

YouTube再生中にバッファリングのスピナー（グルグル）が出たまま固まった場合に、自動で検知して復旧する機能を追加します。

## 仕組み

`js/stall-recovery.js`（新規・自己完結、main.js は無変更）が1秒間隔で再生状態を監視し、**再生位置が3秒間進まない**（BUFFERING が続く / PLAYING なのに位置が凍結）場合に停滞と判定します。

停滞検知時はまず **YouTube への疎通確認**（favicon の no-cors fetch、タイムアウト2.5秒）で原因を切り分けます:

- **疎通なし = ネットワークが原因** → 復旧アクションはせず、そのまま回線回復を待機
- **疎通あり = プレイヤー側の問題** → 段階的に復旧

| レベル | アクション |
|---|---|
| 0 | 10秒先へスキップ（壊れたセグメントを飛ばして読み込みを蹴り直す） |
| 1 | 動画を同じ位置から再ロード。プレイリストの場合は次の動画へ |
| 2 | ページごと再読み込み（既存の `?url=` 自動再生パスに乗せ、sessionStorage 経由で再生位置・プレイリストのインデックスを復元） |

正常再生が30秒続いたらレベルはリセットされます。

## 誤検知・暴走対策

- ループのシーク戻りは「進捗」として扱う（位置の変化は前後どちらでも進捗）
- バッファ読み込み割合（`getVideoLoadedFraction`）の増加も進捗とみなす（低速だがデータが流れている間は発火しない）
- PAUSED / CUED / UNSTARTED / ENDED は停滞扱いしない（`?pause=true` のポーズと非干渉）
- バックグラウンドタブからの復帰時・回線復帰時は1停滞期間の猶予を与える
- オフライン中（`navigator.onLine === false`）・疎通確認失敗中はアクションを保留し回線復帰を待つ
- **リロードループ防止**: ページ再読み込みは10分以内に2回まで（超過時はレベル1の再試行に留める）
- `?url=` は main.js が二重デコードするため二重エンコードして引き継ぎ

## 動作確認方法

1. DevTools → Network → リクエストブロック等でプレイヤーの通信だけ阻害（または再生中に googlevideo へのリクエストを失敗させる）→ 約3秒後にレベル0（スキップ）、以降進捗がなければ数秒間隔でレベル1（再ロード）→ レベル2（ページ再読み込み）が console ログとともに発火することを確認
2. ネットワーク全体を切断（OSレベルでオフライン）→ 「ネットワーク疎通なし: 回線回復を待機」のログが出て復旧アクションが発火しないこと、回線復帰後に再生が再開することを確認
3. 短い動画のループ再生・`?pause=true` でのポーズ中・バックグラウンドタブ放置では発火しないことを確認

復旧発生時は GA に `stall_recovery` イベント（level 付き）を送信するため、本番での発生頻度も確認できます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
