### PR TITLE
Googleログインをサイレント更新して自動化

### DIFF
--- a/js/drive-sync.js
+++ b/js/drive-sync.js
@@ -4,7 +4,11 @@
   var SCOPE = 'https://www.googleapis.com/auth/drive.appdata';
   var DRIVE_FILE_NAME = 'yt-loop-history.json';
   var TOKEN_STORAGE_KEY = 'ytDriveToken';
+  var AUTO_LOGIN_STORAGE_KEY = 'ytDriveAutoLogin';
   var PUSH_DEBOUNCE_MS = 1500;
+  var REFRESH_MARGIN_MS = 60 * 1000; // 有効期限切れの60秒前に自動更新する
+  var GIS_WAIT_INTERVAL_MS = 250;
+  var GIS_WAIT_MAX_RETRIES = 20;
 
   var authButton = document.getElementById('authButton');
   var syncStatus = document.getElementById('syncStatus');
@@ -15,6 +19,7 @@
   var cachedFileId = null;
   var pushTimer = null;
   var pendingHistory = null;
+  var refreshTimer = null;
 
   function isConfigured() {
     return GOOGLE_CLIENT_ID.indexOf('YOUR_CLIENT_ID') === -1;
@@ -38,6 +43,8 @@
     try {
       sessionStorage.setItem(TOKEN_STORAGE_KEY, JSON.stringify({ accessToken: accessToken, expiresAt: tokenExpiresAt }));
     } catch (e) { /* 無視 */ }
+    markConsented();
+    scheduleRefresh();
   }
 
   function clearToken() {
@@ -45,10 +52,37 @@
     tokenExpiresAt = 0;
     cachedFileId = null;
     try { sessionStorage.removeItem(TOKEN_STORAGE_KEY); } catch (e) { /* 無視 */ }
+    if (refreshTimer) {
+      clearTimeout(refreshTimer);
+      refreshTimer = null;
+    }
   }
 
   function isLoggedIn() {
     return !!accessToken && tokenExpiresAt > Date.now();
+  }
+
+  // 一度ログインに成功したことをlocalStorageに記録する（ブラウザを閉じても消えない）。
+  // 次回訪問時、この記録があればGoogle側のセッションを使ったサイレント再ログインを試みる。
+  function hasConsentedBefore() {
+    try { return localStorage.getItem(AUTO_LOGIN_STORAGE_KEY) === 'true'; } catch (e) { return false; }
+  }
+
+  function markConsented() {
+    try { localStorage.setItem(AUTO_LOGIN_STORAGE_KEY, 'true'); } catch (e) { /* 無視 */ }
+  }
+
+  function clearConsent() {
+    try { localStorage.removeItem(AUTO_LOGIN_STORAGE_KEY); } catch (e) { /* 無視 */ }
+  }
+
+  // アクセストークンの有効期限が切れる前に、ユーザー操作なしで更新を試みる。
+  function scheduleRefresh() {
+    if (refreshTimer) clearTimeout(refreshTimer);
+    var delay = Math.max(0, tokenExpiresAt - Date.now() - REFRESH_MARGIN_MS);
+    refreshTimer = setTimeout(function () {
+      requestToken(true);
+    }, delay);
   }
 
   function updateUi() {
@@ -171,15 +205,22 @@
     }, PUSH_DEBOUNCE_MS);
   }
 
-  function login() {
+  // silent=trueの場合、ポップアップやアカウント選択UIを出さずに、
+  // ブラウザに残っているGoogleのログインセッションを使ってトークン取得のみを試みる。
+  // ユーザーがGoogleに未ログイン、もしくは同意が無効化されている場合は何も起きず失敗する。
+  function requestToken(silent) {
     if (!isConfigured()) {
-      alert('Google連携が未設定です。README記載のセットアップ手順を確認してください。');
-      console.warn('[drive-sync] GOOGLE_CLIENT_IDが未設定のためログインできません。');
+      if (!silent) {
+        alert('Google連携が未設定です。README記載のセットアップ手順を確認してください。');
+        console.warn('[drive-sync] GOOGLE_CLIENT_IDが未設定のためログインできません。');
+      }
       return;
     }
     if (typeof google === 'undefined' || !google.accounts || !google.accounts.oauth2) {
-      alert('Googleログインの読み込みに失敗しました。しばらくしてから再度お試しください。');
-      console.warn('[drive-sync] Google Identity Servicesがまだ読み込まれていません。');
+      if (!silent) {
+        alert('Googleログインの読み込みに失敗しました。しばらくしてから再度お試しください。');
+        console.warn('[drive-sync] Google Identity Servicesがまだ読み込まれていません。');
+      }
       return;
     }
     if (!tokenClient) {
@@ -197,7 +238,29 @@
         }
       });
     }
-    tokenClient.requestAccessToken();
+    tokenClient.requestAccessToken(silent ? { prompt: '' } : {});
+  }
+
+  function login() {
+    requestToken(false);
+  }
+
+  // 過去にログイン済みの記録があれば、ページ表示時に自動でサイレントログインを試みる。
+  function trySilentLogin() {
+    if (isLoggedIn() || !hasConsentedBefore()) return;
+    requestToken(true);
+  }
+
+  // GIS(Google Identity Services)はasync/deferで読み込まれるため、
+  // 読み込み完了を待ってからサイレントログインを試みる。
+  function waitForGisAndTrySilentLogin(retriesLeft) {
+    if (typeof retriesLeft === 'undefined') retriesLeft = GIS_WAIT_MAX_RETRIES;
+    if (typeof google !== 'undefined' && google.accounts && google.accounts.oauth2) {
+      trySilentLogin();
+      return;
+    }
+    if (retriesLeft <= 0) return;
+    setTimeout(function () { waitForGisAndTrySilentLogin(retriesLeft - 1); }, GIS_WAIT_INTERVAL_MS);
   }
 
   function logout() {
@@ -205,6 +268,7 @@
       google.accounts.oauth2.revoke(accessToken, function () { /* no-op */ });
     }
     clearToken();
+    clearConsent();
     updateUi();
   }
 
@@ -222,7 +286,10 @@
   loadStoredToken();
   updateUi();
   if (isLoggedIn()) {
+    scheduleRefresh();
     pullAndMerge();
+  } else {
+    waitForGisAndTrySilentLogin();
   }
 
   window.driveSync = {


### PR DESCRIPTION
## Summary
- 履歴のクラウド同期(Google Drive)で使うアクセストークンが `sessionStorage` のみに保存されており、ブラウザを閉じるたびに失効し、毎回「Googleでログイン」を手動で押し直す必要があった
- Google Identity Services のサイレント更新(`prompt: ''`)を使い、有効期限の60秒前にバックグラウンドでアクセストークンを自動更新するようにした
- 一度ログインに成功したことを `localStorage` に記録し、次回訪問時（ブラウザ再起動後などトークンが失われている場合）はブラウザに残っている Google のログインセッションを使って自動的に再ログインを試みるようにした
- 明示的にログアウトした場合はこの自動ログイン記録を削除し、以降は自動ログインしないようにした
- 資格情報（パスワード等）の保存やスクレイピングは行わず、Google公式のサイレントトークン取得APIのみを利用している

Closes #15

## Test plan
- [ ] `js/drive-sync.js` を静的にレビューし、既存のトークン管理ロジックとの整合性を確認
- [ ] 実ブラウザでGoogleログイン → タブを閉じて再度開いた際に、確認なしで自動的に「同期中」状態に戻ることを確認
- [ ] ログアウト後に再読み込みしても自動ログインが行われないことを確認
- [ ] トークン有効期限が近づいた際、操作中でもログアウト状態にならず同期が継続することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)