### PR TITLE
自分のYouTubeプレイリストから履歴へのURLインポート機能を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ https://m2u7bf.github.io/yt-loop-player/index.html
 * 入力履歴の保持（最大20件）
   * 新しい履歴ほど上に表示されます。
 * Googleアカウントでの入力履歴のクラウド同期
+* Googleアカウントの自分のYouTubeプレイリストから履歴へのURLインポート
 
 ## 開発経緯
 * 作業BGM用にYouTubeの動画を無限再生するツールがほしかった。

--- a/css/style.css
+++ b/css/style.css
@@ -160,28 +160,115 @@ button.btn_10:hover {
   text-align: center;
 }
 
-#syncBar {
+/* 設定・プレイリストインポート共通のモーダル */
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 2000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.modal-backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+}
+.modal-dialog {
+  position: relative;
+  width: min(90vw, 420px);
+  max-height: 70vh;
+  background: #212121;
+  border: 1px solid #303030;
+  border-radius: 6px;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+.modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 12px;
+  border-bottom: 1px solid #303030;
+  color: #fff;
+  font-size: 14px;
+}
+.modal-close {
+  background: transparent;
+  border: none;
+  color: #aaa;
+  cursor: pointer;
+  font-size: 18px;
+  line-height: 1;
+}
+.modal-close:hover {
+  color: #fff;
+}
+
+/* 設定パネル */
+#settingsButton .material-symbols-outlined {
+  color: #e3e3e3;
+  vertical-align: middle;
+}
+#settingsBody {
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+#settingsBody #syncBar {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 8px;
-  padding: 6px 8px;
-  border-bottom: 1px solid #303030;
-  background: #1a1a1a;
-  font-size: 12px;
+  font-size: 13px;
   color: #aaa;
 }
-#syncBar #authButton {
+#settingsBody #authButton,
+#settingsBody .settings-action {
   background: transparent;
   border: 1px solid #303030;
   border-radius: 4px;
   color: #fff;
   cursor: pointer;
-  font-size: 12px;
-  padding: 3px 8px;
+  font-size: 13px;
+  padding: 6px 10px;
 }
-#syncBar #authButton:hover {
+#settingsBody #authButton:hover,
+#settingsBody .settings-action:hover {
   background: #303030;
+}
+#settingsBody .settings-action {
+  width: 100%;
+  text-align: left;
+}
+
+/* プレイリストインポート用モーダル */
+#playlistImportStatus {
+  padding: 8px 12px;
+  color: #aaa;
+  font-size: 12px;
+}
+#playlistImportList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  overflow-y: auto;
+}
+#playlistImportList li.playlist-import-item {
+  padding: 10px 12px;
+  color: #fff;
+  cursor: pointer;
+  border-top: 1px solid #303030;
+}
+#playlistImportList li.playlist-import-item:hover {
+  background: #303030;
+}
+#playlistImportList li.playlist-import-empty {
+  padding: 10px 12px;
+  color: #888;
+  text-align: center;
 }
 
 #historyTabs {

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
   <title>YouTubeリピート再生</title>
   <link rel="stylesheet" href="css/style.css" type="text/css">
   <link rel="icon" href="icon/logo.ico">
-  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,400,0,0&icon_names=pause,delete,stop" />
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,400,0,0&icon_names=pause,delete,stop,settings" />
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="theme-color" content="#000000">
@@ -19,10 +19,6 @@
     <div class="input-wrapper">
       <input style="width: 100%;" type="text" id="youtubeUrl" class="input_1" placeholder="YouTube動画のURLを入力" autocomplete="off">
       <div id="historyPanel" class="hidden">
-        <div id="syncBar">
-          <span id="syncStatus">未ログイン</span>
-          <button type="button" id="authButton">Googleでログイン</button>
-        </div>
         <ul id="historyList"></ul>
         <div id="historyTabs">
           <button type="button" class="history-tab active" data-tab="solo">solo</button>
@@ -31,15 +27,47 @@
       </div>
     </div>
     <button id="playButton" class="btn_10">再生</button>
+    <button id="settingsButton" class="btn_10" aria-label="設定"><span class="material-symbols-outlined">settings</span></button>
     <button id="pauseButton" class="btn_10 hidden"><span class="material-symbols-outlined">pause</span></button>
     <button id="stopButton" class="btn_10 hidden"><span class="material-symbols-outlined">stop</span></button>
   </div>
 
   <div id="player"></div>
 
+  <div id="settingsPanel" class="hidden modal-overlay">
+    <div id="settingsBackdrop" class="modal-backdrop"></div>
+    <div id="settingsDialog" class="modal-dialog">
+      <div class="modal-header">
+        <span>設定</span>
+        <button type="button" id="settingsClose" class="modal-close">×</button>
+      </div>
+      <div id="settingsBody">
+        <div id="syncBar">
+          <span id="syncStatus">未ログイン</span>
+          <button type="button" id="authButton">Googleでログイン</button>
+        </div>
+        <button type="button" id="importPlaylistButton" class="settings-action">プレイリストをインポート</button>
+      </div>
+    </div>
+  </div>
+
+  <div id="playlistImportPanel" class="hidden modal-overlay">
+    <div id="playlistImportBackdrop" class="modal-backdrop"></div>
+    <div id="playlistImportDialog" class="modal-dialog">
+      <div class="modal-header">
+        <span>プレイリストを選択</span>
+        <button type="button" id="playlistImportClose" class="modal-close">×</button>
+      </div>
+      <div id="playlistImportStatus"></div>
+      <ul id="playlistImportList"></ul>
+    </div>
+  </div>
+
    <script src="js/main.js"></script>
    <script src="js/history.js"></script>
    <script src="js/drive-sync.js"></script>
+   <script src="js/playlist-import.js"></script>
+   <script src="js/settings-panel.js"></script>
    <script src="js/stall-recovery.js"></script>
 </body>
 

--- a/js/drive-sync.js
+++ b/js/drive-sync.js
@@ -1,7 +1,7 @@
 // Googleアカウントでログインし、入力履歴をGoogle Driveのアプリ専用領域(appDataFolder)に同期する。
 (function () {
   var GOOGLE_CLIENT_ID = '611114130619-45p9qds3g7hht8e36nchabmnv4lhupff.apps.googleusercontent.com';
-  var SCOPE = 'https://www.googleapis.com/auth/drive.appdata';
+  var SCOPE = 'https://www.googleapis.com/auth/drive.appdata https://www.googleapis.com/auth/youtube.readonly';
   var DRIVE_FILE_NAME = 'yt-loop-history.json';
   var TOKEN_STORAGE_KEY = 'ytDriveToken';
   var PUSH_DEBOUNCE_MS = 1500;
@@ -229,6 +229,7 @@
     login: login,
     logout: logout,
     push: push,
-    isLoggedIn: isLoggedIn
+    isLoggedIn: isLoggedIn,
+    getAccessToken: function () { return isLoggedIn() ? accessToken : null; }
   };
 })();

--- a/js/playlist-import.js
+++ b/js/playlist-import.js
@@ -1,0 +1,154 @@
+// Googleアカウントの自分のYouTubeプレイリストから、動画URLを履歴にインポートする。
+(function () {
+  var YOUTUBE_API_BASE = 'https://www.googleapis.com/youtube/v3';
+
+  var importButton = document.getElementById('importPlaylistButton');
+  var panel = document.getElementById('playlistImportPanel');
+  var backdrop = document.getElementById('playlistImportBackdrop');
+  var closeButton = document.getElementById('playlistImportClose');
+  var statusEl = document.getElementById('playlistImportStatus');
+  var listEl = document.getElementById('playlistImportList');
+
+  function ytFetch(url) {
+    var token = window.driveSync && window.driveSync.getAccessToken();
+    if (!token) return Promise.reject(new Error('未ログインです'));
+    return fetch(url, { headers: { Authorization: 'Bearer ' + token } }).then(function (res) {
+      if (!res.ok) {
+        return res.json().catch(function () { return null; }).then(function (body) {
+          var message = (body && body.error && body.error.message) || res.statusText;
+          throw new Error(message);
+        });
+      }
+      return res.json();
+    });
+  }
+
+  function setStatus(text) {
+    if (statusEl) statusEl.textContent = text || '';
+  }
+
+  function openPanel() {
+    if (panel) panel.classList.remove('hidden');
+  }
+
+  function closePanel() {
+    if (panel) panel.classList.add('hidden');
+  }
+
+  // 自分のプレイリストを全件取得（ページネーション対応）
+  function fetchAllPlaylists() {
+    var playlists = [];
+    function loadPage(pageToken) {
+      var url = YOUTUBE_API_BASE + '/playlists?part=snippet,contentDetails&mine=true&maxResults=50' +
+        (pageToken ? '&pageToken=' + pageToken : '');
+      return ytFetch(url).then(function (data) {
+        playlists = playlists.concat(data.items || []);
+        if (data.nextPageToken) return loadPage(data.nextPageToken);
+        return playlists;
+      });
+    }
+    return loadPage();
+  }
+
+  // 指定プレイリストの動画を全件取得（ページネーション対応）
+  function fetchAllPlaylistItems(playlistId) {
+    var items = [];
+    function loadPage(pageToken) {
+      var url = YOUTUBE_API_BASE + '/playlistItems?part=snippet&playlistId=' + encodeURIComponent(playlistId) +
+        '&maxResults=50' + (pageToken ? '&pageToken=' + pageToken : '');
+      return ytFetch(url).then(function (data) {
+        items = items.concat(data.items || []);
+        if (data.nextPageToken) return loadPage(data.nextPageToken);
+        return items;
+      });
+    }
+    return loadPage();
+  }
+
+  function renderPlaylists(playlists) {
+    listEl.innerHTML = '';
+    if (playlists.length === 0) {
+      var empty = document.createElement('li');
+      empty.className = 'playlist-import-empty';
+      empty.textContent = 'プレイリストが見つかりません';
+      listEl.appendChild(empty);
+      return;
+    }
+    playlists.forEach(function (playlist) {
+      var li = document.createElement('li');
+      li.className = 'playlist-import-item';
+      var count = playlist.contentDetails ? playlist.contentDetails.itemCount : null;
+      li.textContent = playlist.snippet.title + (count != null ? '（' + count + '件）' : '');
+      li.addEventListener('click', function () {
+        importPlaylist(playlist.id, playlist.snippet.title);
+      });
+      listEl.appendChild(li);
+    });
+  }
+
+  // プレイリスト内動画のURLをクエリパラメータなしの形式で履歴に追加する
+  function importPlaylist(playlistId, playlistTitle) {
+    listEl.innerHTML = '';
+    setStatus(playlistTitle + ' を読み込み中...');
+    fetchAllPlaylistItems(playlistId).then(function (items) {
+      var history = loadHistory();
+      var added = 0;
+      items.forEach(function (item) {
+        var videoId = item.snippet && item.snippet.resourceId && item.snippet.resourceId.videoId;
+        if (!videoId) return;
+        var url = 'https://www.youtube.com/watch?v=' + videoId;
+        var title = item.snippet.title;
+        history = history.filter(function (h) { return h.url !== url; });
+        history.unshift({ url: url, title: title, updatedAt: Date.now() });
+        added++;
+      });
+      history = history.slice(0, MAX_HISTORY);
+      saveHistory(history);
+      setStatus(added + '件インポートしました');
+      setTimeout(function () {
+        closePanel();
+        renderHistory();
+      }, 800);
+    }).catch(function (e) {
+      console.warn('[playlist-import] インポートに失敗しました', e);
+      setStatus('インポートに失敗しました: ' + e.message);
+    });
+  }
+
+  function openImport() {
+    if (!window.driveSync || !window.driveSync.isLoggedIn()) {
+      alert('プレイリストをインポートするにはGoogleログインが必要です。');
+      return;
+    }
+    if (window.settingsPanel) window.settingsPanel.close();
+    listEl.innerHTML = '';
+    openPanel();
+    setStatus('プレイリストを取得中...');
+    fetchAllPlaylists().then(function (playlists) {
+      setStatus('');
+      renderPlaylists(playlists);
+    }).catch(function (e) {
+      console.warn('[playlist-import] プレイリスト取得に失敗しました', e);
+      setStatus('プレイリストの取得に失敗しました: ' + e.message);
+    });
+  }
+
+  if (importButton) {
+    importButton.addEventListener('click', function (e) {
+      e.stopPropagation();
+      openImport();
+    });
+  }
+  if (closeButton) {
+    closeButton.addEventListener('click', function (e) {
+      e.stopPropagation();
+      closePanel();
+    });
+  }
+  if (backdrop) {
+    backdrop.addEventListener('click', function (e) {
+      e.stopPropagation();
+      closePanel();
+    });
+  }
+})();

--- a/js/settings-panel.js
+++ b/js/settings-panel.js
@@ -1,0 +1,36 @@
+// 設定パネル（Googleログイン・プレイリストインポートの起点）の開閉を管理する。
+(function () {
+  var settingsButton = document.getElementById('settingsButton');
+  var panel = document.getElementById('settingsPanel');
+  var backdrop = document.getElementById('settingsBackdrop');
+  var closeButton = document.getElementById('settingsClose');
+
+  function open() {
+    if (panel) panel.classList.remove('hidden');
+  }
+
+  function close() {
+    if (panel) panel.classList.add('hidden');
+  }
+
+  if (settingsButton) {
+    settingsButton.addEventListener('click', function (e) {
+      e.stopPropagation();
+      open();
+    });
+  }
+  if (closeButton) {
+    closeButton.addEventListener('click', function (e) {
+      e.stopPropagation();
+      close();
+    });
+  }
+  if (backdrop) {
+    backdrop.addEventListener('click', function (e) {
+      e.stopPropagation();
+      close();
+    });
+  }
+
+  window.settingsPanel = { open: open, close: close };
+})();


### PR DESCRIPTION
## Summary
- Googleログインのスコープに `youtube.readonly` を追加し、自分のYouTubeプレイリスト一覧を取得できるようにした
- プレイリストを選択すると、収録動画のURL（クエリパラメータなしの `https://www.youtube.com/watch?v=VIDEO_ID` 形式）を一括で履歴にインポートする機能を追加
- 再生ボタンの右横に設定（歯車）ボタンを新設し、Googleログイン・プレイリストインポートをそこにまとめてUIを整理

## Closes
Closes #18

## 実装詳細
- `js/drive-sync.js`: OAuthスコープに `youtube.readonly` を追加、`getAccessToken()` を公開
- `js/playlist-import.js`（新規）: 自分のプレイリスト一覧の取得・選択・動画URLの履歴インポートを担当
- `js/settings-panel.js`（新規）: 設定パネル（歯車ボタン）の開閉制御
- `index.html` / `css/style.css`: 設定パネル・プレイリスト選択モーダルのUIを追加、既存のsyncBarを設定パネル配下へ移動

## Test plan
- [x] ローカルサーバーでUI表示・設定パネルの開閉・プレイリスト選択→履歴インポート（fetchをスタブ化）の一連の流れを確認
- [x] インポートされたURLがクエリパラメータなしの形式であることを確認
- [ ] 実際のGoogleアカウントでログインし、本物のプレイリストからのインポートを確認（要手動確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)