### PR TITLE
設定アイコンをインラインSVGに変更

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -207,9 +207,15 @@ button.btn_10:hover {
 }
 
 /* 設定パネル */
-#settingsButton .material-symbols-outlined {
+#settingsButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 6px;
+}
+#settingsButton .settings-icon {
   color: #e3e3e3;
-  vertical-align: middle;
+  display: block;
 }
 #settingsBody {
   padding: 12px;

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
   <title>YouTubeリピート再生</title>
   <link rel="stylesheet" href="css/style.css" type="text/css">
   <link rel="icon" href="icon/logo.ico">
-  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,400,0,0&icon_names=pause,delete,stop,settings" />
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,400,0,0&icon_names=pause,delete,stop" />
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="theme-color" content="#000000">
@@ -27,7 +27,11 @@
       </div>
     </div>
     <button id="playButton" class="btn_10">再生</button>
-    <button id="settingsButton" class="btn_10" aria-label="設定"><span class="material-symbols-outlined">settings</span></button>
+    <button id="settingsButton" class="btn_10" aria-label="設定">
+      <svg class="settings-icon" viewBox="0 0 24 24" width="22" height="22" aria-hidden="true">
+        <path fill="currentColor" d="M19.14,12.94c0.04,-0.3 0.06,-0.61 0.06,-0.94c0,-0.32 -0.02,-0.64 -0.07,-0.94l2.03,-1.58c0.18,-0.14 0.23,-0.41 0.12,-0.61l-1.92,-3.32c-0.12,-0.22 -0.37,-0.29 -0.59,-0.22l-2.39,0.96c-0.5,-0.38 -1.03,-0.7 -1.62,-0.94L14.4,2.81c-0.04,-0.24 -0.24,-0.41 -0.48,-0.41h-3.84c-0.24,0 -0.43,0.17 -0.47,0.41L9.25,5.35C8.66,5.59 8.12,5.92 7.63,6.29L5.24,5.33c-0.22,-0.08 -0.47,0 -0.59,0.22L2.74,8.87C2.62,9.08 2.66,9.34 2.86,9.48l2.03,1.58C4.84,11.36 4.8,11.69 4.8,12s0.02,0.64 0.07,0.94l-2.03,1.58c-0.18,0.14 -0.23,0.41 -0.12,0.61l1.92,3.32c0.12,0.22 0.37,0.29 0.59,0.22l2.39,-0.96c0.5,0.38 1.03,0.7 1.62,0.94l0.36,2.54c0.05,0.24 0.24,0.41 0.48,0.41h3.84c0.24,0 0.44,-0.17 0.47,-0.41l0.36,-2.54c0.59,-0.24 1.13,-0.56 1.62,-0.94l2.39,0.96c0.22,0.08 0.47,0 0.59,-0.22l1.92,-3.32c0.12,-0.22 0.07,-0.47 -0.12,-0.61L19.14,12.94z M12,15.6c-1.98,0 -3.6,-1.62 -3.6,-3.6s1.62,-3.6 3.6,-3.6s3.6,1.62 3.6,3.6S13.98,15.6 12,15.6z" />
+      </svg>
+    </button>
     <button id="pauseButton" class="btn_10 hidden"><span class="material-symbols-outlined">pause</span></button>
     <button id="stopButton" class="btn_10 hidden"><span class="material-symbols-outlined">stop</span></button>
   </div>


### PR DESCRIPTION
## Summary
- PR #19 マージ後に発見した不具合の修正。Material Symbolsの `icon_names` 複数指定がブラウザで読み込めず設定（歯車）アイコンが表示されないことがあったため、外部フォントに依存しないインラインSVGへ切り替え
- `icon_names` から不要になった `settings` を削除し、既存の pause/delete/stop の読み込みには影響しない

🤖 Generated with [Claude Code](https://claude.com/claude-code)