### PR TITLE
URL入力欄以外のボタンの背景を透明にする

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -52,14 +52,13 @@ input.input_1 {
 
 button.btn_10 {
   display: inline-block;
-  background-color: #222222;
+  background-color: transparent;
   outline: 0;
   cursor: pointer;
   border-radius: 6px;
   border: 2px solid #303030;
   color: white;
   padding: 6px 12px;
-  box-shadow: rgba(0, 0, 0, 0.07) 0px 2px 4px 0px, rgba(0, 0, 0, 0.05) 0px 1px 1.5px 0px;
   font-size: 16px;
   height: 42px;
   margin-left: 5px;
@@ -68,7 +67,8 @@ button.btn_10 {
 }
 
 button.btn_10:hover {
-  background-color: #606060;
+  background-color: transparent;
+  border-color: #606060;
   color: #fff;
 }
 
@@ -246,7 +246,8 @@ button.icon-btn {
 }
 #settingsBody #authButton:hover,
 #settingsBody .settings-action:hover {
-  background: #303030;
+  background: transparent;
+  border-color: #606060;
 }
 #settingsBody .settings-action {
   width: 100%;
@@ -292,6 +293,7 @@ button.icon-btn {
   padding: 3px 0;
   background: transparent;
   border: none;
+  border-bottom: 2px solid transparent;
   border-radius: 4px;
   color: #aaa;
   cursor: pointer;
@@ -299,15 +301,16 @@ button.icon-btn {
   font-weight: 600;
   letter-spacing: 0.06em;
   text-transform: uppercase;
-  transition: background 0.15s ease, color 0.15s ease;
+  transition: border-color 0.15s ease, color 0.15s ease;
 }
 #historyTabs .history-tab:hover {
   color: #fff;
-  background: #303030;
+  background: transparent;
 }
 #historyTabs .history-tab.active {
   color: #fff;
-  background: #4d4d4d;
+  background: transparent;
+  border-bottom-color: #e3e3e3;
 }
 
 .hidden {

--- a/css/style.css
+++ b/css/style.css
@@ -56,7 +56,7 @@ button.btn_10 {
   outline: 0;
   cursor: pointer;
   border-radius: 6px;
-  border: 2px solid #303030;
+  border: 2px solid transparent;
   color: white;
   padding: 6px 12px;
   font-size: 16px;
@@ -237,7 +237,7 @@ button.icon-btn {
 #settingsBody #authButton,
 #settingsBody .settings-action {
   background: transparent;
-  border: 1px solid #303030;
+  border: 1px solid transparent;
   border-radius: 4px;
   color: #fff;
   cursor: pointer;


### PR DESCRIPTION
## Summary
- URL入力欄（`#youtubeUrl`）を除く、自前実装しているすべての `<button>` 要素（再生・一時停止・停止・設定・Googleログイン・プレイリストインポート・履歴の閉じるボタン・履歴タブなど）の背景色を透明に変更
- ホバー時・選択中（履歴タブのactive状態）の視覚フィードバックは、背景の塗りつぶしからボーダー色の変化（履歴タブは下線）に置き換え、操作性を保ちつつ見た目をミニマルにした
- YouTube再生用のiframe内部は対象外（自前実装部分のみのスコープ）

## Test plan
- [x] ローカルでCSSの変更差分をレビューし、対象範囲（`<button>`要素のみ、入力欄・iframeは除外）を確認
- [ ] 実ブラウザでの見た目・ホバー/選択状態の視認性を確認（要手動確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)