### PR TITLE
検索アイコンからYouTube動画を検索できる機能を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ https://m2u7bf.github.io/yt-loop-player/index.html
   * 単体動画とプレイリストで履歴タブが分かれています。
 * Googleアカウントでの入力履歴のクラウド同期
 * Googleアカウントの自分のYouTubeプレイリストから履歴へのURLインポート
+* 検索アイコンからのYouTube動画検索（要Googleログイン）
 
 ## 開発経緯
 * 作業BGM用にYouTubeの動画を無限再生するツールがほしかった。

--- a/css/style.css
+++ b/css/style.css
@@ -292,6 +292,55 @@ button.icon-btn {
   text-align: center;
 }
 
+/* YouTube検索モーダル */
+#searchBody {
+  padding: 12px;
+}
+#searchBody #searchInput {
+  width: 100%;
+  box-sizing: border-box;
+}
+#searchStatus {
+  padding: 0 12px 8px;
+  color: var(--color-text-muted);
+  font-size: 12px;
+}
+#searchResultList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  overflow-y: auto;
+}
+#searchResultList li.search-result-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  color: var(--color-text);
+  cursor: pointer;
+  border-top: 1px solid var(--color-border);
+}
+#searchResultList li.search-result-item:hover {
+  background: var(--color-border);
+}
+#searchResultList li.search-result-item .search-result-thumb {
+  width: 60px;
+  height: 45px;
+  object-fit: cover;
+  border-radius: 4px;
+  flex-shrink: 0;
+}
+#searchResultList li.search-result-item .search-result-title {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+#searchResultList li.search-result-empty {
+  padding: 10px 12px;
+  color: var(--color-text-faint);
+  text-align: center;
+}
+
 #historyTabs {
   display: flex;
   gap: 4px;

--- a/index.html
+++ b/index.html
@@ -26,6 +26,11 @@
         </div>
       </div>
     </div>
+    <button id="searchButton" class="btn_10 icon-btn" aria-label="検索">
+      <svg viewBox="0 0 24 24" width="20" height="20" aria-hidden="true">
+        <path fill="currentColor" d="M15.5,14h-0.79l-0.28,-0.27C15.41,12.59 16,11.11 16,9.5C16,5.91 13.09,3 9.5,3S3,5.91 3,9.5S5.91,16 9.5,16c1.61,0 3.09,-0.59 4.23,-1.57l0.27,0.28v0.79l5,4.99L20.49,19L15.5,14z M9.5,14C7.01,14 5,11.99 5,9.5S7.01,5 9.5,5S14,7.01 14,9.5S11.99,14 9.5,14z" />
+      </svg>
+    </button>
     <button id="playButton" class="btn_10 icon-btn" aria-label="再生">
       <svg viewBox="0 0 24 24" width="20" height="20" aria-hidden="true">
         <path fill="currentColor" d="M8,5v14l11,-7z" />
@@ -75,10 +80,26 @@
     </div>
   </div>
 
+  <div id="searchPanel" class="hidden modal-overlay">
+    <div id="searchBackdrop" class="modal-backdrop"></div>
+    <div id="searchDialog" class="modal-dialog">
+      <div class="modal-header">
+        <span>YouTube検索</span>
+        <button type="button" id="searchClose" class="modal-close">×</button>
+      </div>
+      <div id="searchBody">
+        <input type="text" id="searchInput" class="input_1" placeholder="キーワードを入力してEnter" autocomplete="off">
+      </div>
+      <div id="searchStatus"></div>
+      <ul id="searchResultList"></ul>
+    </div>
+  </div>
+
   <script type="module" src="js/history-ui.js"></script>
   <script type="module" src="js/player.js"></script>
   <script type="module" src="js/drive-sync.js"></script>
   <script type="module" src="js/playlist-import.js"></script>
+  <script type="module" src="js/youtube-search.js"></script>
   <script type="module" src="js/settings-panel.js"></script>
   <script type="module" src="js/stall-recovery.js"></script>
 </body>

--- a/js/youtube-search.js
+++ b/js/youtube-search.js
@@ -1,0 +1,122 @@
+// 検索アイコンからYouTube Data APIで動画を検索し、選択した動画をそのまま再生する。
+const YOUTUBE_API_BASE = 'https://www.googleapis.com/youtube/v3';
+
+const searchButton = document.getElementById('searchButton');
+const panel = document.getElementById('searchPanel');
+const backdrop = document.getElementById('searchBackdrop');
+const closeButton = document.getElementById('searchClose');
+const searchInput = document.getElementById('searchInput');
+const statusEl = document.getElementById('searchStatus');
+const listEl = document.getElementById('searchResultList');
+const urlInput = document.getElementById('youtubeUrl');
+
+function setStatus(text) {
+  if (statusEl) statusEl.textContent = text || '';
+}
+
+function openPanel() {
+  if (panel) panel.classList.remove('hidden');
+  listEl.innerHTML = '';
+  setStatus('');
+  if (searchInput) {
+    searchInput.value = '';
+    searchInput.focus();
+  }
+}
+
+function closePanel() {
+  if (panel) panel.classList.add('hidden');
+}
+
+function selectVideo(videoId) {
+  urlInput.value = `https://www.youtube.com/watch?v=${videoId}`;
+  closePanel();
+  document.getElementById('playButton').click();
+}
+
+function renderResults(items) {
+  listEl.innerHTML = '';
+  if (items.length === 0) {
+    const empty = document.createElement('li');
+    empty.className = 'search-result-empty';
+    empty.textContent = '見つかりませんでした';
+    listEl.appendChild(empty);
+    return;
+  }
+  items.forEach((item) => {
+    const videoId = item.id && item.id.videoId;
+    if (!videoId) return;
+
+    const li = document.createElement('li');
+    li.className = 'search-result-item';
+
+    const thumb = document.createElement('img');
+    thumb.className = 'search-result-thumb';
+    thumb.src = (item.snippet.thumbnails && item.snippet.thumbnails.default && item.snippet.thumbnails.default.url) || '';
+    thumb.alt = '';
+
+    const title = document.createElement('span');
+    title.className = 'search-result-title';
+    title.textContent = item.snippet.title;
+
+    li.appendChild(thumb);
+    li.appendChild(title);
+    li.addEventListener('click', () => selectVideo(videoId));
+    listEl.appendChild(li);
+  });
+}
+
+async function runSearch(query) {
+  const token = window.driveSync && window.driveSync.getAccessToken();
+  if (!token) {
+    setStatus('検索にはGoogleログインが必要です。');
+    return;
+  }
+  setStatus('検索中...');
+  listEl.innerHTML = '';
+  try {
+    const url = `${YOUTUBE_API_BASE}/search?part=snippet&type=video&maxResults=25&q=${encodeURIComponent(query)}`;
+    const res = await fetch(url, { headers: { Authorization: `Bearer ${token}` } });
+    if (!res.ok) {
+      const body = await res.json().catch(() => null);
+      throw new Error((body && body.error && body.error.message) || res.statusText);
+    }
+    const data = await res.json();
+    setStatus('');
+    renderResults(data.items || []);
+  } catch (e) {
+    console.warn('[youtube-search] 検索に失敗しました', e);
+    setStatus(`検索に失敗しました: ${e.message}`);
+  }
+}
+
+if (searchButton) {
+  searchButton.addEventListener('click', (e) => {
+    e.stopPropagation();
+    if (!window.driveSync || !window.driveSync.isLoggedIn()) {
+      alert('YouTube検索にはGoogleログインが必要です。設定からログインしてください。');
+      return;
+    }
+    openPanel();
+  });
+}
+if (closeButton) {
+  closeButton.addEventListener('click', (e) => {
+    e.stopPropagation();
+    closePanel();
+  });
+}
+if (backdrop) {
+  backdrop.addEventListener('click', (e) => {
+    e.stopPropagation();
+    closePanel();
+  });
+}
+if (searchInput) {
+  searchInput.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter') {
+      const query = searchInput.value.trim();
+      if (query) runSearch(query);
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- コントロールバーに検索アイコン（虫眼鏡）を追加
- クリックするとYouTube検索モーダルが開き、キーワードを入力してEnterで検索できる
- 検索結果（サムネイル・タイトル）をクリックすると、そのままURL入力欄に反映して再生開始
- 検索にはYouTube Data API v3の`search.list`を使用。既存のGoogleログイン（プレイリストインポート機能と同じOAuthトークン）を再利用するため、未ログイン時はログインを促すアラートを表示

Closes #23

## Test plan
- [x] ローカルサーバーでブラウザ確認: アイコン表示、モーダルの開閉、検索結果の描画（API呼び出しをモックして確認）、結果クリックでURL欄反映・再生開始まで一通り動作確認済み
- [x] コンソールエラーなし
- [ ] 実際のGoogleログイン＋YouTube Data APIでの検索は未検証（ローカル環境でOAuthクレデンシャルの実ログインができないため）

🤖 Generated with [Claude Code](https://claude.com/claude-code)