### PR TITLE
問い合わせ受付機能を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ https://m2u7bf.github.io/yt-loop-player/index.html
 * Googleアカウントでの入力履歴のクラウド同期
 * Googleアカウントの自分のYouTubeプレイリストから履歴へのURLインポート
 * 検索アイコンからのYouTube動画検索（要Googleログイン）
+* 設定画面からのお問い合わせ（GitHub Issueの作成画面へ移動します）
 
 ## 開発経緯
 * 作業BGM用にYouTubeの動画を無限再生するツールがほしかった。

--- a/css/style.css
+++ b/css/style.css
@@ -263,6 +263,9 @@ button.icon-btn {
 #settingsBody .settings-action {
   width: 100%;
   text-align: left;
+  display: inline-block;
+  text-decoration: none;
+  box-sizing: border-box;
 }
 
 /* プレイリストインポート用モーダル */

--- a/index.html
+++ b/index.html
@@ -105,6 +105,7 @@
           <button type="button" id="authButton">Googleでログイン</button>
         </div>
         <button type="button" id="importPlaylistButton" class="settings-action">プレイリストをインポート</button>
+        <a id="contactLink" class="settings-action" href="https://github.com/M2U7BF/yt-loop-player/issues/new" target="_blank" rel="noopener noreferrer">お問い合わせ</a>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- 設定パネルに「お問い合わせ」リンクを追加し、GitHub Issueの新規作成画面（別タブ）へ遷移できるようにした
- 本サイトは静的サイト（バックエンドなし）のため、既存のGitHub Issuesをユーザー問い合わせの受付窓口として利用する設計とした
- README「機能」欄に追記

Closes #28

## Test plan
- [x] `node`製の簡易HTTPサーバーでindex.htmlを配信し、`contactLink`要素がHTMLに正しく出力されることを確認
- [ ] GitHub Pages上で設定パネルを開き、「お問い合わせ」リンクからIssue作成画面に遷移できることを目視確認（実機ブラウザでの確認は未実施）

🤖 Generated with [Claude Code](https://claude.com/claude-code)