### PR TITLE
input_1入力時に履歴リストを絞り込む

### DIFF
--- a/js/history-ui.js
+++ b/js/history-ui.js
@@ -124,16 +124,18 @@ export function renderHistory() {
     return;
   }
 
-  const filtered = history.filter((item) =>
-    currentTab === 'list' ? isPlaylistItem(item) : !isPlaylistItem(item)
-  );
+  const query = input.value.trim().toLowerCase();
+
+  const filtered = history
+    .filter((item) => (currentTab === 'list' ? isPlaylistItem(item) : !isPlaylistItem(item)))
+    .filter((item) => !query || item.title.toLowerCase().includes(query) || item.url.toLowerCase().includes(query));
 
   historyList.innerHTML = '';
 
   if (filtered.length === 0) {
     const empty = document.createElement('li');
     empty.className = 'history-empty';
-    empty.textContent = '履歴がありません';
+    empty.textContent = query ? '一致する履歴がありません' : '履歴がありません';
     historyList.appendChild(empty);
   }
 
@@ -175,6 +177,10 @@ input.addEventListener('change', () => {
 });
 
 input.addEventListener('focus', () => {
+  renderHistory();
+});
+
+input.addEventListener('input', () => {
   renderHistory();
 });
 


### PR DESCRIPTION
## Summary
- `#youtubeUrl`(class `input_1`)に文字列を入力した際、履歴パネル(`#historyList`)を入力文字列で絞り込むようにしました。
- 一致判定は履歴の `title` / `url` に対する部分一致(大文字小文字を区別しない)です。
- 既存のタブ(solo/list)による絞り込みと組み合わせて動作します。
- 該当履歴が0件のときは「一致する履歴がありません」を表示するようにしました(履歴自体が0件のときの「履歴がありません」とは文言を分けています)。

Closes #26

## Test plan
- [x] `js/history-ui.js` の構文チェック(Node `vm.SourceTextModule`でパース確認)
- [ ] ブラウザで `#youtubeUrl` にフォーカスして履歴を表示し、文字を入力して絞り込まれることを確認
- [ ] solo/listタブ切り替えと組み合わせても正しく絞り込まれることを確認