### PR TITLE
検索・シャッフルアイコンを設定モーダル内に移動

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ https://m2u7bf.github.io/yt-loop-player/index.html
   * 単体動画とプレイリストで履歴タブが分かれています。
 * Googleアカウントでの入力履歴のクラウド同期
 * Googleアカウントの自分のYouTubeプレイリストから履歴へのURLインポート
-* 検索アイコンからのYouTube動画検索（要Googleログイン）
+* 設定モーダルからのYouTube動画検索（要Googleログイン）
 
 ## 開発経緯
 * 作業BGM用にYouTubeの動画を無限再生するツールがほしかった。

--- a/css/style.css
+++ b/css/style.css
@@ -268,7 +268,17 @@ button.icon-btn {
 }
 #settingsBody .settings-action {
   width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 10px;
   text-align: left;
+}
+#settingsBody .settings-action svg {
+  flex-shrink: 0;
+  color: var(--color-icon);
+}
+#settingsBody .settings-action.active {
+  color: #3d7aff;
 }
 
 /* プレイリストインポート用モーダル */

--- a/index.html
+++ b/index.html
@@ -63,16 +63,6 @@
         </div>
       </div>
     </div>
-    <button id="searchButton" class="btn_10 icon-btn" aria-label="検索">
-      <svg viewBox="0 0 24 24" width="20" height="20" aria-hidden="true">
-        <path fill="currentColor" d="M15.5,14h-0.79l-0.28,-0.27C15.41,12.59 16,11.11 16,9.5C16,5.91 13.09,3 9.5,3S3,5.91 3,9.5S5.91,16 9.5,16c1.61,0 3.09,-0.59 4.23,-1.57l0.27,0.28v0.79l5,4.99L20.49,19L15.5,14z M9.5,14C7.01,14 5,11.99 5,9.5S7.01,5 9.5,5S14,7.01 14,9.5S11.99,14 9.5,14z" />
-      </svg>
-    </button>
-    <button id="shuffleButton" class="btn_10 icon-btn" aria-label="シャッフル再生" title="プレイリストをシャッフル再生">
-      <svg viewBox="0 0 24 24" width="20" height="20" aria-hidden="true">
-        <path fill="currentColor" d="M10.59,9.17L5.41,4L4,5.41l5.17,5.17L10.59,9.17z M14.5,4l2.04,2.04L4,18.59L5.41,20L17.96,7.46L20,9.5V4H14.5z M14.83,13.41l-1.41,1.41l3.13,3.13L14.5,20H20v-5.5l-2.04,2.04L14.83,13.41z" />
-      </svg>
-    </button>
     <button id="playButton" class="btn_10 icon-btn" aria-label="再生">
       <svg viewBox="0 0 24 24" width="20" height="20" aria-hidden="true">
         <path fill="currentColor" d="M8,5v14l11,-7z" />
@@ -109,6 +99,18 @@
           <span id="syncStatus">未ログイン</span>
           <button type="button" id="authButton">Googleでログイン</button>
         </div>
+        <button type="button" id="searchButton" class="settings-action" aria-label="検索">
+          <svg viewBox="0 0 24 24" width="20" height="20" aria-hidden="true">
+            <path fill="currentColor" d="M15.5,14h-0.79l-0.28,-0.27C15.41,12.59 16,11.11 16,9.5C16,5.91 13.09,3 9.5,3S3,5.91 3,9.5S5.91,16 9.5,16c1.61,0 3.09,-0.59 4.23,-1.57l0.27,0.28v0.79l5,4.99L20.49,19L15.5,14z M9.5,14C7.01,14 5,11.99 5,9.5S7.01,5 9.5,5S14,7.01 14,9.5S11.99,14 9.5,14z" />
+          </svg>
+          <span>YouTubeを検索</span>
+        </button>
+        <button type="button" id="shuffleButton" class="settings-action" aria-label="シャッフル再生" title="プレイリストをシャッフル再生">
+          <svg viewBox="0 0 24 24" width="20" height="20" aria-hidden="true">
+            <path fill="currentColor" d="M10.59,9.17L5.41,4L4,5.41l5.17,5.17L10.59,9.17z M14.5,4l2.04,2.04L4,18.59L5.41,20L17.96,7.46L20,9.5V4H14.5z M14.83,13.41l-1.41,1.41l3.13,3.13L14.5,20H20v-5.5l-2.04,2.04L14.83,13.41z" />
+          </svg>
+          <span>シャッフル再生</span>
+        </button>
         <button type="button" id="importPlaylistButton" class="settings-action">プレイリストをインポート</button>
       </div>
     </div>

--- a/js/youtube-search.js
+++ b/js/youtube-search.js
@@ -97,6 +97,7 @@ if (searchButton) {
       alert('YouTube検索にはGoogleログインが必要です。設定からログインしてください。');
       return;
     }
+    if (window.settingsPanel) window.settingsPanel.close();
     openPanel();
   });
 }


### PR DESCRIPTION
## Summary
- close #31
- トップの操作バーにあった検索アイコン・シャッフルアイコンを削除し、設定モーダル（`#settingsBody`）内に「YouTubeを検索」「シャッフル再生」ボタンとして移動した
- 検索ボタンをクリックした際、プレイリストインポートと同様に設定モーダルを閉じてから検索モーダルを開くようにした
- シャッフルボタンのON/OFF表示（`.active`クラス）が設定モーダル内でも機能するようCSSを追加
- README内の説明文を新しい導線に合わせて更新

## Test plan
- [x] ローカルで静的サーバーを起動し、Playwrightでヘッドレスブラウザ確認
  - トップの操作バーから検索・シャッフルアイコンが消えていること
  - 設定モーダル内に検索・シャッフルボタンが表示されること
  - シャッフルボタンのクリックで有効/無効表示が切り替わること
  - 未ログイン状態で検索ボタンを押すとアラートが表示され、設定モーダルは開いたままであること
  - コンソールエラーが発生しないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)